### PR TITLE
Add sr-only class for hidden accessibility elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -554,6 +554,17 @@ body {
 }
 
 /* Utility Classes */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
 .min-h-screen {
     min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- add `.sr-only` rule to support skip links and accessibility announcements

## Testing
- `grep -n "sr-only" -n style.css`

------
https://chatgpt.com/codex/tasks/task_e_6886a9c905348325b4904e001ead58a6