### PR TITLE
Add hero block pattern and rename sections

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -236,22 +236,22 @@ function cassette_brutal_customize_register($wp_customize) {
         'type'        => 'text',
     ));
     
-    // Design Philosophy Section
+    // Good, Better, Best Section
     $wp_customize->add_section('cassette_brutal_philosophy', array(
-        'title'       => esc_html__('Design Philosophy', 'cassette-brutal'),
-        'description' => esc_html__('Customize the design philosophy section.', 'cassette-brutal'),
+        'title'       => esc_html__('Good, Better, Best', 'cassette-brutal'),
+        'description' => esc_html__('Customize the Good, Better, Best section.', 'cassette-brutal'),
         'priority'    => 35,
     ));
     
     // Philosophy Title
     $wp_customize->add_setting('philosophy_title', array(
-        'default'           => 'Design Philosophy',
+        'default'           => 'Good, Better, Best',
         'sanitize_callback' => 'sanitize_text_field',
         'transport'         => 'postMessage',
     ));
     
     $wp_customize->add_control('philosophy_title', array(
-        'label'       => esc_html__('Philosophy Section Title', 'cassette-brutal'),
+        'label'       => esc_html__('Good, Better, Best Section Title', 'cassette-brutal'),
         'section'     => 'cassette_brutal_philosophy',
         'type'        => 'text',
     ));
@@ -433,5 +433,27 @@ function cassette_brutal_post_navigation() {
         echo '<div class="post-navigation py-16 border-t border-border">' . cassette_brutal_container($navigation) . '</div>';
     }
 }
+
+/**
+ * Register block patterns for reusable collections.
+ */
+function cassette_brutal_register_patterns() {
+    register_block_pattern_category(
+        'cassette-collections',
+        array(
+            'label' => esc_html__( 'Collections', 'cassette-brutal' ),
+        )
+    );
+
+    register_block_pattern(
+        'cassette-brutal/hero-section',
+        array(
+            'title'      => esc_html__( 'Hero Section', 'cassette-brutal' ),
+            'categories' => array( 'cassette-collections' ),
+            'content'    => file_get_contents( get_template_directory() . '/patterns/hero.php' ),
+        )
+    );
+}
+add_action( 'init', 'cassette_brutal_register_patterns' );
 ?>
 

--- a/index.php
+++ b/index.php
@@ -29,11 +29,11 @@ get_header(); ?>
             </div>
         </section>
 
-        <!-- Design Philosophy Section -->
+        <!-- Good, Better, Best Section -->
         <section class="py-24">
             <div class="container">
                 <div class="text-center mb-20">
-                    <h2 class="text-headline mb-6 philosophy-title"><?php echo esc_html(get_theme_mod('philosophy_title', __('Design Philosophy', 'cassette-brutal'))); ?></h2>
+                    <h2 class="text-headline mb-6 philosophy-title"><?php echo esc_html(get_theme_mod('philosophy_title', __('Good, Better, Best', 'cassette-brutal'))); ?></h2>
                     <p class="text-body text-muted-foreground max-w-2xl mx-auto philosophy-subtitle">
                         <?php echo esc_html(get_theme_mod('philosophy_subtitle', __('Where Stefan Sagmeister meets Jony Ive — confident, intelligent, and quietly opinionated.', 'cassette-brutal'))); ?>
                     </p>
@@ -162,13 +162,13 @@ get_header(); ?>
             </div>
         </section>
 
-        <!-- Content Block: Feature Highlight -->
+        <!-- Content Block: Call to Action -->
         <section class="py-20 bg-surface-elevated">
             <div class="container">
                 <div class="grid grid-cols-12 gap-12 items-center">
                     <div class="col-span-6">
                         <div class="space-y-6">
-                            <h2 class="text-headline"><?php esc_html_e('Feature Highlight', 'cassette-brutal'); ?></h2>
+                            <h2 class="text-headline"><?php esc_html_e('Call to Action', 'cassette-brutal'); ?></h2>
                             <p class="text-body text-muted-foreground">
                                 <?php esc_html_e('Showcase your key features with this elegant two-column layout.', 'cassette-brutal'); ?>
                                 <?php esc_html_e('Perfect for highlighting product benefits, service offerings, or key differentiators.', 'cassette-brutal'); ?>
@@ -261,7 +261,7 @@ get_header(); ?>
             </div>
         </section>
 
-        <!-- Alternative: Vertical Design Philosophy Cards -->
+        <!-- Alternative: Vertical Good, Better, Best Cards -->
         <section class="py-24 bg-surface-elevated">
             <div class="container">
                 <div class="text-center mb-20">

--- a/patterns/hero.php
+++ b/patterns/hero.php
@@ -1,0 +1,18 @@
+<section class="py-32 gradient-subtle">
+    <div class="container">
+        <div class="text-center max-w-4xl mx-auto">
+            <h1 class="text-hero mb-8">
+                <span>Design that</span><br />
+                <span class="text-accent">speaks first</span>
+            </h1>
+            <p class="text-subhead text-muted-foreground mb-12">
+                Clean, bright, open — with just the right hint of playful provocation.
+                Where grid meets grace, and structure finds its subtle rebellion.
+            </p>
+            <div class="flex gap-6 justify-center items-center">
+                <a href="#" class="btn btn-primary btn-lg">Start Creating</a>
+                <a href="#" class="btn btn-brutal btn-lg">Explore Design</a>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- rename Design Philosophy section to **Good, Better, Best**
- rename Feature Highlight section to **Call to Action**
- add reusable block pattern for the hero section and register a new `cassette-collections` category

## Testing
- `php -l functions.php`
- `php -l index.php`
- `php -l patterns/hero.php`


------
https://chatgpt.com/codex/tasks/task_e_6886ae4372dc8325ae2fd12bc02642d8